### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete multi-character sanitization

### DIFF
--- a/lib/medium.js
+++ b/lib/medium.js
@@ -1,3 +1,5 @@
+import sanitizeHtml from 'sanitize-html';
+
 export async function fetchMediumArticles() {
     try {
         let url = 'https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/@louisphilip_s';
@@ -43,8 +45,8 @@ function extractImage(content) {
 
 function cleanDescription(description) {
     if (!description) return '';
-    // Remove HTML tags
-    const cleanText = description.replace(/<[^>]*>/g, '');
+    // Remove HTML tags using a robust library
+    const cleanText = sanitizeHtml(description, { allowedTags: [], allowedAttributes: {} });
     // Truncate
     return cleanText.length > 150 ? cleanText.substring(0, 150) + '...' : cleanText;
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-dom": "19.2.0",
     "react-icons": "^5.5.0",
     "sass": "^1.94.2",
-    "swiper": "^12.0.3"
+    "swiper": "^12.0.3",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "eslint": "^9",


### PR DESCRIPTION
Potential fix for [https://github.com/louisphilip/louisphilip.github.io/security/code-scanning/2](https://github.com/louisphilip/louisphilip.github.io/security/code-scanning/2)

The best fix is to use a standard, well-tested sanitization library like `sanitize-html` to remove all potentially dangerous HTML and return clean plain text. This will ensure that all tags, including `<script>` or broken/malformed input, are thoroughly and safely removed—far more robust than the regex approach. The fix is limited to the `cleanDescription` function (lines 44–50), but requires an additional import of `sanitize-html` and possibly some configuration (e.g., disallow all tags to return just plain text).  
If external dependencies are not allowed, a fallback would be to perform repeated replacements until no tags remain. But since using a library is specifically recommended and avoids subtle bugs, we should use `sanitize-html`.

Required changes:
- Add `import sanitizeHtml from 'sanitize-html';` (Node ESM style, but adjust to require() if CJS).
- Update `cleanDescription` to use `sanitizeHtml` with configuration to strip out all tags (i.e., `{allowedTags: [], allowedAttributes: {}}`).
- Rest of function (truncation logic) remains the same.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
