### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,4 +1,6 @@
 name: Lighthouse
+permissions:
+  contents: read
 on: 
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/louisphilip/louisphilip.github.io/security/code-scanning/1](https://github.com/louisphilip/louisphilip.github.io/security/code-scanning/1)

To fix the problem, add a `permissions` key specifying the minimal required privileges for the workflow. For many workflows that only need access to repository contents in a read-only mode, setting `permissions: { contents: read }` at the workflow or job level suffices. In this case, the workflow appears to simply check websites with Lighthouse and does not create or modify content in the repository or on GitHub. Therefore, add `permissions: contents: read` at the root level of the workflow file, just below the `name` and above `on`, so it applies to all jobs by default unless overridden. No other imports, methods, or definitions are necessary as this is purely a change to the YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
