### PR TITLE
Feat: Add GCP Study Guides showcase page pointing to pde.louisphilipshahim.com

### DIFF
--- a/app/gcp-study-guides/StudyGuides.module.scss
+++ b/app/gcp-study-guides/StudyGuides.module.scss
@@ -1,0 +1,247 @@
+.container {
+  max-width: var(--container-width);
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.headerSection {
+  margin-bottom: 50px;
+  text-align: left;
+}
+
+.title {
+  font-family: var(--font-heading);
+  font-size: 48px;
+  font-weight: 800;
+  margin-bottom: 20px;
+  background: var(--gradient-primary);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  display: inline-block;
+}
+
+.subtitle {
+  font-family: var(--font-main);
+  font-size: 18px;
+  line-height: 1.8;
+  color: var(--text-secondary);
+  max-width: 800px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(500px, 1fr));
+  gap: 30px;
+  margin-bottom: 60px;
+}
+
+@media (max-width: 1100px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  padding: 35px;
+  position: relative;
+  overflow: hidden;
+  transition: transform var(--transition-normal), border-color var(--transition-normal), box-shadow var(--transition-normal);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: transparent;
+    transition: background var(--transition-normal);
+  }
+
+  &.active {
+    border-color: rgba(14, 165, 233, 0.4);
+    box-shadow: var(--shadow-glow);
+
+    &::before {
+      background: var(--gradient-primary);
+    }
+
+    &:hover {
+      transform: translateY(-5px);
+      border-color: rgba(14, 165, 233, 0.6);
+      box-shadow: 0 15px 30px rgba(14, 165, 233, 0.2);
+    }
+  }
+
+  &.upcoming {
+    opacity: 0.85;
+
+    &::before {
+      background: var(--border-color);
+    }
+
+    &:hover {
+      transform: translateY(-2px);
+      border-color: var(--text-muted);
+    }
+  }
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 25px;
+}
+
+.iconWrapper {
+  font-size: 32px;
+  color: var(--primary-color);
+  background: rgba(14, 165, 233, 0.1);
+  padding: 12px;
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card.upcoming .iconWrapper {
+  color: var(--text-muted);
+  background: rgba(110, 118, 129, 0.1);
+}
+
+.badge {
+  font-family: var(--font-main);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 50px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.activeBadge {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.2) 0%, rgba(45, 212, 191, 0.2) 100%);
+  color: #2dd4bf;
+  border: 1px solid rgba(45, 212, 191, 0.3);
+}
+
+.upcomingBadge {
+  background: rgba(110, 118, 129, 0.1);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+}
+
+.plannedBadge {
+  background: rgba(245, 166, 35, 0.1);
+  color: var(--accent-color);
+  border: 1px solid rgba(245, 166, 35, 0.2);
+}
+
+.cardContent {
+  margin-bottom: 30px;
+  flex-grow: 1;
+}
+
+.cardTitle {
+  font-family: var(--font-heading);
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.cardStatus {
+  font-family: var(--font-main);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--primary-color);
+  margin-bottom: 15px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.card.upcoming .cardStatus {
+  color: var(--text-secondary);
+}
+
+.cardDesc {
+  font-family: var(--font-main);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  margin-bottom: 20px;
+}
+
+.featuresList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.featureItem {
+  font-family: var(--font-main);
+  font-size: 14px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  svg {
+    font-size: 16px;
+    color: var(--primary-color);
+    flex-shrink: 0;
+  }
+}
+
+.card.upcoming .featureItem svg {
+  color: var(--text-muted);
+}
+
+.buttonContainer {
+  margin-top: auto;
+}
+
+.actionButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-family: var(--font-main);
+  font-size: 15px;
+  font-weight: 600;
+  padding: 12px 24px;
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition: all var(--transition-fast);
+  width: 100%;
+}
+
+.activeButton {
+  background: var(--gradient-primary);
+  color: #0f1115;
+  box-shadow: 0 4px 12px rgba(14, 165, 233, 0.2);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(14, 165, 233, 0.4);
+    opacity: 0.95;
+  }
+}
+
+.disabledButton {
+  background: rgba(110, 118, 129, 0.05);
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  cursor: not-allowed;
+}

--- a/app/gcp-study-guides/page.js
+++ b/app/gcp-study-guides/page.js
@@ -1,0 +1,151 @@
+import styles from "./StudyGuides.module.scss";
+import { FiDatabase, FiCpu, FiCode, FiLock, FiArrowRight, FiCheck } from "react-icons/fi";
+
+export const metadata = {
+    title: "GCP Study Labs | Louis Philip",
+    description: "An interactive, visual, and case-driven study ecosystem for Google Cloud certifications.",
+};
+
+export default function GCPStudyGuides() {
+    const guides = [
+        {
+            id: "pde",
+            title: "Professional Data Engineer",
+            category: "Data & AI Analytics",
+            status: "Active Study Lab 🚀",
+            badgeClass: styles.activeBadge,
+            cardClass: styles.active,
+            icon: <FiDatabase />,
+            statusDesc: "Ready — Live on Custom Domain",
+            description: "Deep-dives into scalable analytical warehousing, micro-windowed stream event orchestration, visual ETL pipelines, and structural ML data preps. Includes dynamic design decision trees, visual sketchnotes, and a 30-question interactive simulator.",
+            bullets: [
+                "30 scenario-based high-fidelity mock exam questions",
+                "Interactive Step-by-Step Design Decision Wizards",
+                "Priyanka Vergadia's conceptual visual sketchnotes integration",
+                "Local Storage stateful Hands-on Lab checklist and milestones"
+            ],
+            link: "https://pde.louisphilipshahim.com",
+            ctaText: "Launch Study Lab",
+            disabled: false
+        },
+        {
+            id: "pca",
+            title: "Professional Cloud Architect",
+            category: "Infrastructure & Security",
+            status: "Upcoming Lab ⏳",
+            badgeClass: styles.upcomingBadge,
+            cardClass: styles.upcoming,
+            icon: <FiCpu />,
+            statusDesc: "Coming Soon — Q3 2026",
+            description: "Designed to evaluate enterprise-grade business resilience, multi-region hybrid compute networking, complex storage scaling (Spanner vs Bigtable vs AlloyDB), and governance postures.",
+            bullets: [
+                "Resilient Disaster Recovery & Failover Workflows",
+                "High-density GKE & Compute Hybrid Design Patterns",
+                "Corporate Landing Zone & Network Perimeter Blueprints"
+            ],
+            link: "#",
+            ctaText: "In Development",
+            disabled: true
+        },
+        {
+            id: "devops",
+            title: "Professional Cloud DevOps Engineer",
+            category: "CI/CD & Operations",
+            status: "Pipeline Planned 🛠️",
+            badgeClass: styles.upcomingBadge,
+            cardClass: styles.upcoming,
+            icon: <FiCode />,
+            statusDesc: "Planned — Q4 2026",
+            description: "Focuses on building fully-automated CI/CD pipelines, robust logging metrics architectures, Site Reliability Engineering (SRE) service boundaries, and complex Terraform state structures.",
+            bullets: [
+                "GitHub Actions & Cloud Build Orchestration Matrices",
+                "Operations Suite Monitoring & SRE SLI/SLO Boundaries",
+                "Multi-Environment Dry-run Terraform Blueprint States"
+            ],
+            link: "#",
+            ctaText: "Planning",
+            disabled: true
+        },
+        {
+            id: "security",
+            title: "Professional Cloud Security Engineer",
+            category: "Identity & Protection",
+            status: "Upcoming Blueprint 🛡️",
+            badgeClass: styles.plannedBadge,
+            cardClass: styles.upcoming,
+            icon: <FiLock />,
+            statusDesc: "Planned — Q1 2027",
+            description: "Addresses advanced security posturing, VPC Service Controls (VPC-SC), Cloud KMS cryptographic architectures, column-level/IAM sharing topologies, and regulatory compliance benchmarks.",
+            bullets: [
+                "VPC-SC Perimeters & Cross-Project Bridge Connectors",
+                "Hardware Security Module (HSM) & Customer-Managed Keys (CMEK)",
+                "Security Command Center Alerts & Active Threat Appraisals"
+            ],
+            link: "#",
+            ctaText: "Planning",
+            disabled: true
+        }
+    ];
+
+    return (
+        <div className={`container section ${styles.container}`}>
+            <div className={styles.headerSection}>
+                <h1 className={styles.title}>GCP Study Labs</h1>
+                <p className={styles.subtitle}>
+                    An interactive, visual, and case-driven certification study ecosystem designed to bridge 
+                    advanced Google Cloud engineering theory with production-ready reference architectures and blueprints.
+                </p>
+            </div>
+
+            <div className={styles.grid}>
+                {guides.map((guide) => (
+                    <div key={guide.id} className={`${styles.card} ${guide.cardClass}`}>
+                        <div>
+                            <div className={styles.cardHeader}>
+                                <div className={styles.iconWrapper}>
+                                    {guide.icon}
+                                </div>
+                                <span className={`${styles.badge} ${guide.badgeClass}`}>
+                                    {guide.status}
+                                </span>
+                            </div>
+
+                            <div className={styles.cardContent}>
+                                <h3 className={styles.cardTitle}>{guide.title}</h3>
+                                <p className={styles.cardStatus}>{guide.statusDesc}</p>
+                                <p className={styles.cardDesc}>{guide.description}</p>
+
+                                <ul className={styles.featuresList}>
+                                    {guide.bullets.map((bullet, idx) => (
+                                        <li key={idx} className={styles.featureItem}>
+                                            <FiCheck />
+                                            <span>{bullet}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        </div>
+
+                        <div className={styles.buttonContainer}>
+                            {guide.disabled ? (
+                                <button className={`${styles.actionButton} ${styles.disabledButton}`} disabled>
+                                    {guide.ctaText}
+                                </button>
+                            ) : (
+                                <a 
+                                    href={guide.link} 
+                                    target="_blank" 
+                                    rel="noopener noreferrer" 
+                                    className={`${styles.actionButton} ${styles.activeButton}`}
+                                >
+                                    <span>{guide.ctaText}</span>
+                                    <FiArrowRight />
+                                </a>
+                            )}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/components/layout/Header.jsx
+++ b/components/layout/Header.jsx
@@ -16,6 +16,7 @@ const navItems = [
     { name: "Writing", path: "/writing" },
     { name: "Reading", path: "/reading" },
     { name: "Portfolio", path: "/portfolio" },
+    { name: "GCP Study Labs", path: "/gcp-study-guides" },
     { name: "Contact", path: "/contact" },
 ];
 


### PR DESCRIPTION
Adds a dedicated showcase page for Google Cloud Certification study labs.

Updates:
- Create page router path `app/gcp-study-guides/page.js` displaying cards for Professional Data Engineer, Professional Cloud Architect, Professional Cloud DevOps, and Professional Cloud Security certifications.
- Style the page using premium glassmorphism layouts and hover states in a dedicated module stylesheet `app/gcp-study-guides/StudyGuides.module.scss`.
- Point the Professional Data Engineer 'Launch Study Lab' action button directly to your custom domain: **https://pde.louisphilipshahim.com**.
- Integrate 'GCP Study Labs' as a standard option in the global desktop/mobile navigation header (`components/layout/Header.jsx`) for high discoverability.